### PR TITLE
Use `bin/rails s` in Procfile.dev instead of `rackup`, since `rackup` does not print verbose query logs

### DIFF
--- a/lib/generators/mobile_workflow/install/templates/Procfile.dev
+++ b/lib/generators/mobile_workflow/install/templates/Procfile.dev
@@ -1,1 +1,1 @@
-web: bundle exec rackup config.ru -p $PORT
+web: bin/rails s -p $PORT


### PR DESCRIPTION
Use `bin/rails s` in Procfile.dev instead of `rackup`, since `rackup` does not print verbose query logs
