### PR TITLE
[MW-1654] Make `mobile_workflow` to calculate checksum asynchronously when receiving a request from Amazon SNS

### DIFF
--- a/app/controllers/concerns/mobile_workflow/s3_storable.rb
+++ b/app/controllers/concerns/mobile_workflow/s3_storable.rb
@@ -10,7 +10,7 @@ module MobileWorkflow
           identifier = binary[:identifier]
           object_attribute = identifier.split(".")[0] # ensure extension doesnt get added here
           extension = binary[:mimetype].split('/')[1] # i.e. image/jpg --> jpg, video/mp4 --> mp4
-          metadata = binary.slice('md5')
+          metadata = binary.slice(:md5)
 
           {
             identifier: identifier,

--- a/app/controllers/concerns/mobile_workflow/s3_storable.rb
+++ b/app/controllers/concerns/mobile_workflow/s3_storable.rb
@@ -10,10 +10,11 @@ module MobileWorkflow
           identifier = binary[:identifier]
           object_attribute = identifier.split(".")[0] # ensure extension doesnt get added here
           extension = binary[:mimetype].split('/')[1] # i.e. image/jpg --> jpg, video/mp4 --> mp4
-      
+          metadata = binary.slice('md5')
+
           {
             identifier: identifier,
-            url: presigned_url("#{object.class.name.underscore}/#{object.id}/#{object_attribute}/#{s3_object_uuid}.#{extension}"),
+            url: presigned_url("#{object.class.name.underscore}/#{object.id}/#{object_attribute}/#{s3_object_uuid}.#{extension}", metadata: metadata),
             method: "PUT"
           }
         end
@@ -24,8 +25,8 @@ module MobileWorkflow
         SecureRandom.uuid
       end
       
-      def presigned_url(key)
-        presigner.presigned_url(:put_object, bucket: ENV['AWS_BUCKET_NAME'], key: key, metadata: {})
+      def presigned_url(key, metadata: {})
+        presigner.presigned_url(:put_object, bucket: ENV['AWS_BUCKET_NAME'], key: key, metadata: metadata)
       end
   
       def presigner

--- a/app/controllers/mobile_workflow/sns_notifications_controller.rb
+++ b/app/controllers/mobile_workflow/sns_notifications_controller.rb
@@ -10,26 +10,14 @@ module MobileWorkflow
         when 'SubscriptionConfirmation'
           confirm_subscription ? (head :ok) : (head :bad_request)
         else
-          add_attachment
+          AddAttachmentJob.perform_later(object, object_key, attribute_name)
+          head :ok
         end
+      rescue ActiveRecord::RecordNotFound
+        head :not_found
       end
  
       private
-      def add_attachment
-        begin
-          @object = find_object
-          @object.send("#{attribute_name}=",active_record_blob)
-          if @object.save
-            head :ok
-          else
-            Rails.logger.warn "Error saving object: #{@object} #{object.errors.full_messages}"
-            head :unprocessable_entity
-          end
-        rescue NameError => e
-          Rails.logger.warn "Error attaching object: #{e.message}"
-          head :unprocessable_entity
-        end
-      end
        
       def verify_request_authenticity
         head :unauthorized if raw_post.blank?
@@ -37,22 +25,11 @@ module MobileWorkflow
         #head :unauthorized if raw_post.blank? || !message_verifier.authentic?(raw_post) # Not working
       end
   
-      def active_record_blob
-        s3_object = s3_bucket.object(object_key)
-        checksum_base64 = checksum_base64(object_key, s3_object)
-        ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size, checksum: checksum_base64, content_type: s3_object.content_type
-      end
-  
-      def checksum_base64(object_key, s3_object)
-        path = Tempfile.new(object_key).path
-        s3_object.download_file(path)
-        file = File.new(path)
-        Digest::MD5.file(file).base64digest
-      end
-  
-      def find_object
-        object_class_name, object_id = key_identifiers
-        object_class_name.camelcase.constantize.find(object_id.to_i)
+      def object
+        @object ||= begin
+          object_class_name, object_id = key_identifiers
+          object_class_name.camelcase.constantize.find(object_id.to_i)
+        end
       end
   
       def attribute_name
@@ -91,11 +68,7 @@ module MobileWorkflow
         Rails.logger.warn(e.message)
         return false
       end
-  
-      def s3_bucket
-        Aws::S3::Resource.new(region: ENV['AWS_REGION'], access_key_id: ENV['AWS_ACCESS_ID'], secret_access_key: ENV['AWS_SECRET_KEY']).bucket(ENV['AWS_BUCKET_NAME'])
-      end
-  
+
       def sns_client
         Aws::SNS::Client.new(region: ENV['AWS_REGION'], access_key_id: ENV['AWS_ACCESS_ID'], secret_access_key: ENV['AWS_SECRET_KEY'])
       end

--- a/app/controllers/mobile_workflow/sns_notifications_controller.rb
+++ b/app/controllers/mobile_workflow/sns_notifications_controller.rb
@@ -10,7 +10,7 @@ module MobileWorkflow
         when 'SubscriptionConfirmation'
           confirm_subscription ? (head :ok) : (head :bad_request)
         else
-          AddAttachmentJob.perform_later(object, object_key, attribute_name)
+          AddAttachmentJob.perform_now(object, object_key, attribute_name)
           head :ok
         end
       rescue ActiveRecord::RecordNotFound

--- a/app/jobs/mobile_workflow/add_attachment_job.rb
+++ b/app/jobs/mobile_workflow/add_attachment_job.rb
@@ -13,15 +13,7 @@ module MobileWorkflow
 
     def active_record_blob
       s3_object = s3_bucket.object(object_key)
-      checksum_base64 = checksum_base64(object_key, s3_object)
-      ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size, checksum: checksum_base64, content_type: s3_object.content_type
-    end
-
-    def checksum_base64(object_key, s3_object)
-      path = Tempfile.new(object_key).path
-      s3_object.download_file(path)
-      file = File.new(path)
-      Digest::MD5.file(file).base64digest
+      ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size, checksum: s3_object.metadata['md5'], content_type: s3_object.content_type
     end
 
     def s3_bucket

--- a/app/jobs/mobile_workflow/add_attachment_job.rb
+++ b/app/jobs/mobile_workflow/add_attachment_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module MobileWorkflow
+  class AddAttachmentJob < ApplicationJob
+    def perform(object, object_key, attribute_name)
+      object.send("#{attribute_name}=", active_record_blob)
+      Rails.logger.warn "Error saving object: #{@object} #{object.errors.full_messages}" unless @object.save
+    rescue NameError => e
+      Rails.logger.warn "Error attaching object: #{e.message}"
+    end
+
+    private
+
+    def active_record_blob
+      s3_object = s3_bucket.object(object_key)
+      checksum_base64 = checksum_base64(object_key, s3_object)
+      ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size, checksum: checksum_base64, content_type: s3_object.content_type
+    end
+
+    def checksum_base64(object_key, s3_object)
+      path = Tempfile.new(object_key).path
+      s3_object.download_file(path)
+      file = File.new(path)
+      Digest::MD5.file(file).base64digest
+    end
+
+    def s3_bucket
+      Aws::S3::Resource.new(region: ENV['AWS_REGION'], access_key_id: ENV['AWS_ACCESS_ID'], secret_access_key: ENV['AWS_SECRET_KEY']).bucket(ENV['AWS_BUCKET_NAME'])
+    end
+  end
+end

--- a/spec/controllers/concerns/mobile_workflow/s3_storable_spec.rb
+++ b/spec/controllers/concerns/mobile_workflow/s3_storable_spec.rb
@@ -9,14 +9,25 @@ describe MobileWorkflow::S3Storable do
     let(:object) { double("Object", id: 1, class: double("ObjectClass", name: 'ObjectClass')) }
     let(:params) { {} }
     let(:uuid) { SecureRandom.uuid }
-    
-    before(:each) do 
+    let(:metadata) { {} }
+
+    before(:each) do
       allow(subject).to receive(:s3_object_uuid) { uuid }
-      allow(subject).to receive(:presigned_url).with("object_class/1/image/#{uuid}.jpg") { "https://aws.com/upload" } 
+      allow(subject).to receive(:presigned_url).with("object_class/1/image/#{uuid}.jpg", metadata: metadata) { "https://aws.com/upload" }
     end
-    
+
     context 'single binary' do
       let(:params) { { binaries: [{ identifier: 'image.jpg', mimetype: 'image/jpg' }]} }
+      it { expect(subject.binary_urls(object).count).to eq 1 }
+      it { expect(subject.binary_urls(object)[0][:identifier]).to eq "image.jpg" }
+      it { expect(subject.binary_urls(object)[0][:url]).to eq "https://aws.com/upload" }
+      it { expect(subject.binary_urls(object)[0][:method]).to eq "PUT" }
+    end
+
+    context 'with metadata' do
+      let(:metadata) { { md5: 'fc7925ceff85b44276c576a72cd3f811' } }
+      let(:params) { { binaries: [{ identifier: 'image.jpg', mimetype: 'image/jpg', md5: 'fc7925ceff85b44276c576a72cd3f811' }] } }
+
       it { expect(subject.binary_urls(object).count).to eq 1 }
       it { expect(subject.binary_urls(object)[0][:identifier]).to eq "image.jpg" }
       it { expect(subject.binary_urls(object)[0][:url]).to eq "https://aws.com/upload" }


### PR DESCRIPTION
Resolves https://futureworkshops.atlassian.net/browse/MW-1654
- Extract logic to attach file to a record to a background job
- If the record is not found it will return a 404, this is an accepted status code and the request won't be retried by Amazon SNS.
- According to Amazon SNS docs:
    > Make sure that your endpoint responds to the HTTP POST message from Amazon SNS with the appropriate status code. The connection will time out in 15 seconds. If your endpoint does not respond before the connection times out or if your endpoint returns a status code outside the range of 200–4xx, Amazon SNS will consider the delivery of the message as a failed attempt.
- Add md5 checksum as metadata in the presigned URL
- Get checksum from S3 object metadata instead of downloading the file and calculating it
- Perform the job synchronously for now since it is fast. It can be done async if we notice timeouts
- Add tests for `S3Storable` with metadata



