### PR TITLE
Take the MD5 checksum from S3 etag instead of metadata + make metadata optional

### DIFF
--- a/app/controllers/concerns/mobile_workflow/s3_storable.rb
+++ b/app/controllers/concerns/mobile_workflow/s3_storable.rb
@@ -10,7 +10,7 @@ module MobileWorkflow
           identifier = binary[:identifier]
           object_attribute = identifier.split(".")[0] # ensure extension doesnt get added here
           extension = binary[:mimetype].split('/')[1] # i.e. image/jpg --> jpg, video/mp4 --> mp4
-          metadata = binary.slice(:md5)
+          metadata = binary[:metadata]
 
           {
             identifier: identifier,
@@ -25,7 +25,7 @@ module MobileWorkflow
         SecureRandom.uuid
       end
       
-      def presigned_url(key, metadata: {})
+      def presigned_url(key, metadata: nil)
         presigner.presigned_url(:put_object, bucket: ENV['AWS_BUCKET_NAME'], key: key, metadata: metadata)
       end
   
@@ -36,7 +36,6 @@ module MobileWorkflow
       def s3_client
         Aws::S3::Client.new(region: ENV['AWS_REGION'], access_key_id: ENV['AWS_ACCESS_ID'], secret_access_key: ENV['AWS_SECRET_KEY'])
       end
-      
     end
   end
 end

--- a/app/jobs/mobile_workflow/add_attachment_job.rb
+++ b/app/jobs/mobile_workflow/add_attachment_job.rb
@@ -3,15 +3,15 @@
 module MobileWorkflow
   class AddAttachmentJob < ApplicationJob
     def perform(object, object_key, attribute_name)
-      object.send("#{attribute_name}=", active_record_blob)
-      Rails.logger.warn "Error saving object: #{@object} #{object.errors.full_messages}" unless @object.save
+      object.send("#{attribute_name}=", active_record_blob_from_s3(object_key))
+      Rails.logger.warn "Error saving object: #{object} #{object.errors.full_messages}" unless object.save
     rescue NameError => e
       Rails.logger.warn "Error attaching object: #{e.message}"
     end
 
     private
 
-    def active_record_blob
+    def active_record_blob_from_s3(object_key)
       # etag cannot be used as the MD5 checksum when doing multi-part uploads
       s3_object = s3_bucket.object(object_key)
       ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size,

--- a/app/jobs/mobile_workflow/add_attachment_job.rb
+++ b/app/jobs/mobile_workflow/add_attachment_job.rb
@@ -12,8 +12,10 @@ module MobileWorkflow
     private
 
     def active_record_blob
+      # etag cannot be used as the MD5 checksum when doing multi-part uploads
       s3_object = s3_bucket.object(object_key)
-      ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size, checksum: s3_object.metadata['md5'], content_type: s3_object.content_type
+      ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size,
+                                  checksum: s3_object.etag.delete('"'), content_type: s3_object.content_type
     end
 
     def s3_bucket

--- a/spec/controllers/concerns/mobile_workflow/s3_storable_spec.rb
+++ b/spec/controllers/concerns/mobile_workflow/s3_storable_spec.rb
@@ -9,7 +9,7 @@ describe MobileWorkflow::S3Storable do
     let(:object) { double("Object", id: 1, class: double("ObjectClass", name: 'ObjectClass')) }
     let(:params) { {} }
     let(:uuid) { SecureRandom.uuid }
-    let(:metadata) { {} }
+    let(:metadata) { nil }
 
     before(:each) do
       allow(subject).to receive(:s3_object_uuid) { uuid }
@@ -26,7 +26,7 @@ describe MobileWorkflow::S3Storable do
 
     context 'with metadata' do
       let(:metadata) { { md5: 'fc7925ceff85b44276c576a72cd3f811' } }
-      let(:params) { { binaries: [{ identifier: 'image.jpg', mimetype: 'image/jpg', md5: 'fc7925ceff85b44276c576a72cd3f811' }] } }
+      let(:params) { { binaries: [{ identifier: 'image.jpg', mimetype: 'image/jpg', metadata: metadata }] } }
 
       it { expect(subject.binary_urls(object).count).to eq 1 }
       it { expect(subject.binary_urls(object)[0][:identifier]).to eq "image.jpg" }

--- a/spec/jobs/add_attachment_job_spec.rb
+++ b/spec/jobs/add_attachment_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MobileWorkflow::AddAttachmentJob do
+  let(:record) { double(object_class_name, id: 1) }
+  let(:attribute_name) { 'image' }
+  let(:object_class_name) { 'user' }
+  let(:s3_client) { instance_double(Aws::S3::Resource) }
+  let(:s3_bucket) { instance_double(Aws::S3::Bucket) }
+  let(:active_storage_blob_class) { class_double('ActiveStorage::Blob').as_stubbed_const }
+  let(:blob) { instance_double(ActiveStorage::Blob) }
+  let(:s3_object) do
+    instance_double(Aws::S3::Object, key: object_key, content_type: mimetype,
+                                     size: content_length, etag: etag)
+  end
+  let(:binaries) { [{ identifier: 'image.jpg', mimetype: mimetype }] }
+  let(:uuid) { '12798c4c-cd92-45fa-8635-e55cbc537266' }
+  let(:mimetype) { 'image/jpeg' }
+  let(:content_length) { 1234 }
+  let(:etag) { '\"bedfcb39dd577200c58803afca94c7e7\"' }
+  let(:object_key) { "#{object_class_name}/#{record.id}/#{attribute_name}/#{uuid}.jpeg" }
+
+  before(:each) do
+    stub_const('ENV', 'AWS_ACCESS_ID' => '1234567890', 'AWS_SECRET_KEY' => 'secret', 'AWS_REGION' => 'eu-west-1',
+                      'AWS_BUCKET_NAME' => 'test')
+    allow(Aws::S3::Resource).to receive(:new).with(region: 'eu-west-1', access_key_id: '1234567890',
+                                                   secret_access_key: 'secret').and_return(s3_client)
+    allow(s3_client).to receive(:bucket).with('test').and_return(s3_bucket)
+    allow(s3_bucket).to receive(:object).with(object_key).and_return(s3_object)
+    allow(active_storage_blob_class).to receive(:create!).with(key: object_key, filename: object_key, byte_size: content_length, checksum: etag.delete('"'), content_type: mimetype).and_return(blob)
+    allow(record).to receive("#{attribute_name}=").with(blob).and_return(blob)
+    allow(record).to receive(:save).and_return(true)
+  end
+
+  it 'instantiates s3 client' do
+    described_class.perform_now(record, object_key, attribute_name)
+    expect(Aws::S3::Resource).to have_received(:new).with(region: 'eu-west-1', access_key_id: '1234567890',
+                                                          secret_access_key: 'secret')
+  end
+
+  it 'instantiates s3 bucket' do
+    described_class.perform_now(record, object_key, attribute_name)
+    expect(s3_client).to have_received(:bucket).with('test')
+  end
+
+  it 'retrieves s3 object' do
+    described_class.perform_now(record, object_key, attribute_name)
+    expect(s3_bucket).to have_received(:object).with(object_key)
+  end
+
+  describe '#perform_now' do
+    it 'creates an ActiveStorage::Blob' do
+      expect(active_storage_blob_class).to receive(:create!).with(key: object_key, filename: object_key, byte_size: content_length, checksum: etag.delete('"'), content_type: mimetype)
+      described_class.perform_now(record, object_key, attribute_name)
+    end
+  end
+end


### PR DESCRIPTION
- Make metadata optional + set a more generic way to pass metadata if needed
- Fix AddAttachmentJob + add tests
- Take the MD5 checksum from S3 etag instead of metadata