### PR TITLE
Rescue exceptions when transforming s3 object key to a class and when the record does not implement the attribute method

### DIFF
--- a/app/controllers/mobile_workflow/sns_notifications_controller.rb
+++ b/app/controllers/mobile_workflow/sns_notifications_controller.rb
@@ -13,6 +13,8 @@ module MobileWorkflow
           AddAttachmentJob.perform_now(object, object_key, attribute_name)
           head :ok
         end
+      rescue NameError => e
+        Rails.logger.warn "Error attaching object: #{e.message}"
       rescue ActiveRecord::RecordNotFound
         head :not_found
       end

--- a/app/jobs/mobile_workflow/add_attachment_job.rb
+++ b/app/jobs/mobile_workflow/add_attachment_job.rb
@@ -5,7 +5,7 @@ module MobileWorkflow
     def perform(object, object_key, attribute_name)
       object.send("#{attribute_name}=", active_record_blob_from_s3(object_key))
       Rails.logger.warn "Error saving object: #{object} #{object.errors.full_messages}" unless object.save
-    rescue NameError => e
+    rescue NoMethodError => e
       Rails.logger.warn "Error attaching object: #{e.message}"
     end
 


### PR DESCRIPTION
- Rescue exceptions when transforming s3 object key to a class and when the record does not implement the attribute method
- Rescue exception when constantized class does not exist
- Rescue exception when calling an inexistent writer method on the record

Not rescuing these kind of exceptions makes the request to return a 500 Internal Server Error, and SNS will retry the same request multiple times.