### PR TITLE
Store checksum as a base64 digest instead of a hexadecimal digest

### DIFF
--- a/app/jobs/mobile_workflow/add_attachment_job.rb
+++ b/app/jobs/mobile_workflow/add_attachment_job.rb
@@ -14,12 +14,17 @@ module MobileWorkflow
     def active_record_blob_from_s3(object_key)
       # etag cannot be used as the MD5 checksum when doing multi-part uploads
       s3_object = s3_bucket.object(object_key)
+      base64_digest = hex_to_base64_digest(s3_object.etag.delete('"'))
       ActiveStorage::Blob.create! key: s3_object.key, filename: s3_object.key, byte_size: s3_object.size,
-                                  checksum: s3_object.etag.delete('"'), content_type: s3_object.content_type
+                                  checksum: base64_digest, content_type: s3_object.content_type
     end
 
     def s3_bucket
       Aws::S3::Resource.new(region: ENV['AWS_REGION'], access_key_id: ENV['AWS_ACCESS_ID'], secret_access_key: ENV['AWS_SECRET_KEY']).bucket(ENV['AWS_BUCKET_NAME'])
+    end
+
+    def hex_to_base64_digest(hexdigest)
+      [[hexdigest].pack('H*')].pack('m0')
     end
   end
 end

--- a/spec/jobs/add_attachment_job_spec.rb
+++ b/spec/jobs/add_attachment_job_spec.rb
@@ -28,7 +28,7 @@ describe MobileWorkflow::AddAttachmentJob do
                                                    secret_access_key: 'secret').and_return(s3_client)
     allow(s3_client).to receive(:bucket).with('test').and_return(s3_bucket)
     allow(s3_bucket).to receive(:object).with(object_key).and_return(s3_object)
-    allow(active_storage_blob_class).to receive(:create!).with(key: object_key, filename: object_key, byte_size: content_length, checksum: etag.delete('"'), content_type: mimetype).and_return(blob)
+    allow(active_storage_blob_class).to receive(:create!).with(key: object_key, filename: object_key, byte_size: content_length, checksum: 'y+38s53VdyAMWIA6/KlMfnw=', content_type: mimetype).and_return(blob)
     allow(record).to receive("#{attribute_name}=").with(blob).and_return(blob)
     allow(record).to receive(:save).and_return(true)
   end
@@ -51,7 +51,7 @@ describe MobileWorkflow::AddAttachmentJob do
 
   describe '#perform_now' do
     it 'creates an ActiveStorage::Blob' do
-      expect(active_storage_blob_class).to receive(:create!).with(key: object_key, filename: object_key, byte_size: content_length, checksum: etag.delete('"'), content_type: mimetype)
+      expect(active_storage_blob_class).to receive(:create!).with(key: object_key, filename: object_key, byte_size: content_length, checksum: "y+38s53VdyAMWIA6/KlMfnw=", content_type: mimetype)
       described_class.perform_now(record, object_key, attribute_name)
     end
   end


### PR DESCRIPTION
- Fixes issue checking the integrity of an attachment, since the checksum was not being stored in the same format as `ActiveStorage` does.
- Store checksum as a base64 digest instead of a hexadecimal digest