### PR TITLE
[MW-1690] Create deserializers via mobile workflow install generator

### DIFF
--- a/lib/generators/mobile_workflow/install/install_generator.rb
+++ b/lib/generators/mobile_workflow/install/install_generator.rb
@@ -67,6 +67,18 @@ module MobileWorkflow
         end
       end
 
+      def generate_deserializers
+        say "Generating deserializers"
+
+        model_name_to_properties.each_pair do |model_name, properties|
+          @deserializer_class = model_name
+          @deserializer_properties = properties.split(' ').map { |attribute| attribute.split(':').first }
+
+          template("deserializer.rb.erb", "app/services/#{model_name}_deserializer.rb")
+          template("deserializer_spec.rb.erb", "spec/services/#{model_name}_deserializer_spec.rb")
+        end
+      end
+
       def generate_controllers_and_routes
         say "Generating controllers"
         controller_name_to_actions = open_api_spec.controller_name_to_actions

--- a/lib/generators/mobile_workflow/install/templates/deserializer.rb.erb
+++ b/lib/generators/mobile_workflow/install/templates/deserializer.rb.erb
@@ -1,0 +1,13 @@
+class <%= @deserializer_class.capitalize %>Deserializer
+  def self.parse(params)
+  <% @deserializer_properties.each do |attribute| -%>
+  <%= attribute %> = params.dig(:payload, :<%= attribute %>)
+  <% end -%>
+
+    { <%= @deserializer_class %>: {
+    <% @deserializer_properties.each do |attribute| -%>
+    <%= attribute %>: <%= attribute %>,
+    <% end -%>
+    }.compact }
+  end
+end

--- a/lib/generators/mobile_workflow/install/templates/deserializer_spec.rb.erb
+++ b/lib/generators/mobile_workflow/install/templates/deserializer_spec.rb.erb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'json'
+
+RSpec.describe <%= @deserializer_class.capitalize %>Deserializer do
+  let(:params) { {} }
+
+  describe 'ok' do
+    let(:params) { { payload: payload } }
+    let(:parsed_params) { { <%= @deserializer_class %>: <%= @deserializer_class %>_params } }
+    let(:payload) {
+      {
+    <% @deserializer_properties.each do |attribute| -%>
+    <%= attribute %>: 'string',
+    <% end -%>
+    }
+    }
+    let(:<%= @deserializer_class %>_params) {
+      {
+    <% @deserializer_properties.each do |attribute| -%>
+    <%= attribute %>: 'string',
+    <% end -%>
+    }
+    }
+
+    it { expect(described_class.parse(params)).to eq parsed_params }
+  end
+end

--- a/lib/generators/mobile_workflow/templates/controller.rb.erb
+++ b/lib/generators/mobile_workflow/templates/controller.rb.erb
@@ -41,7 +41,9 @@ class <%= controller_class_name %>Controller < ApiController
     # passport_id = params.dig(:payload, :choose_passport, :selected, :id)
 
     Rails.logger.debug "Pre-rewrite params: #{params}"
-    # Do your rewriting here
+
+    parsed_params = <%= controller_class_name.singularize %>Deserializer.parse(params)
+    params.merge!(parsed_params)
   end
 
   def <%= singular_table_name.underscore %>_params


### PR DESCRIPTION
Resolves https://futureworkshops.atlassian.net/browse/MW-1690.

- Update mobile workflow install generator to create deserializers used to rewrite payload in controller actions
- Create deserializer + spec templates
- Include deserializer invocation in controller template