### PR TITLE
Update attachable to extend active support concern

### DIFF
--- a/app/models/concerns/mobile_workflow/attachable.rb
+++ b/app/models/concerns/mobile_workflow/attachable.rb
@@ -1,5 +1,6 @@
 module MobileWorkflow
   module Attachable
+    extend ActiveSupport::Concern
     include Rails.application.routes.url_helpers
 
     def preview_url(attachment, options: { resize_to_fill: [200, 200] })


### PR DESCRIPTION
Attachable.rb should extend ActiveSupport::Concern in order to access the project's `default_url_options`