### PR TITLE
[MW-1753] Update AppServerGenerator to include Rollbar, SimpleCov and DataMigrate gems

### DIFF
--- a/lib/generators/mobile_workflow/install/install_generator.rb
+++ b/lib/generators/mobile_workflow/install/install_generator.rb
@@ -100,12 +100,6 @@ module MobileWorkflow
         end
       end
 
-      def generate_rollbar
-        generate 'rollbar'
-        gsub_file 'config/initializers/rollbar.rb', 'if Rails.env.test?', 'if Rails.env.test? || Rails.env.development?'
-        copy_file 'config/initializers/mobile_workflow_rollbar.rb'
-      end
-
       def generate_seeds
         template("seeds.rb.erb", "db/seeds.rb", force: true)
       end

--- a/lib/generators/mobile_workflow/install/install_generator.rb
+++ b/lib/generators/mobile_workflow/install/install_generator.rb
@@ -99,7 +99,13 @@ module MobileWorkflow
           route "resources :#{plural_controller_name}, only: [#{actions.map{|a| ":#{a}"}.join(", ")}]"
         end
       end
-      
+
+      def generate_rollbar
+        generate 'rollbar'
+        gsub_file 'config/initializers/rollbar.rb', 'if Rails.env.test?', 'if Rails.env.test? || Rails.env.development?'
+        copy_file 'config/initializers/mobile_workflow_rollbar.rb'
+      end
+
       def generate_seeds
         template("seeds.rb.erb", "db/seeds.rb", force: true)
       end

--- a/lib/generators/mobile_workflow/install/templates/Gemfile.erb
+++ b/lib/generators/mobile_workflow/install/templates/Gemfile.erb
@@ -51,6 +51,10 @@ group :development, :test do
   gem "rufo"
 end
 
+group :test do
+  gem 'simplecov', '~> 0.21.2', require: false
+end
+
 group :production do
   gem 'pg', '>= 0.18', '< 2.0'
 end

--- a/lib/generators/mobile_workflow/install/templates/Gemfile.erb
+++ b/lib/generators/mobile_workflow/install/templates/Gemfile.erb
@@ -37,6 +37,9 @@ gem 'ffi', '~> 1.15.1'
 # Error tracking
 gem 'rollbar'
 
+# Data migrations
+gem 'data_migrate', '~> 7.0.0'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/lib/generators/mobile_workflow/install/templates/Gemfile.erb
+++ b/lib/generators/mobile_workflow/install/templates/Gemfile.erb
@@ -34,6 +34,9 @@ gem 'aws-sdk-sns', '~> 1.23'
 # FFI for Mac M1
 gem 'ffi', '~> 1.15.1'
 
+# Error tracking
+gem 'rollbar'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/lib/generators/mobile_workflow/install/templates/config/initializers/mobile_workflow_rollbar.rb
+++ b/lib/generators/mobile_workflow/install/templates/config/initializers/mobile_workflow_rollbar.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module MobileWorkflow
+  class ApplicationJob < ActiveJob::Base
+    include Rollbar::ActiveJob
+  end
+end

--- a/lib/mobile_workflow/cli/app_builder.rb
+++ b/lib/mobile_workflow/cli/app_builder.rb
@@ -79,6 +79,11 @@ ADMIN_PASSWORD=#{admin_password}
 CODE
     end
     
+    def simplecov
+      append_to_file 'spec/rails_helper.rb', "\n# Config for Test Coverage\nrequire 'simplecov'\nSimpleCov.start\nSimpleCov.minimum_coverage 80\n"
+      append_to_file '.gitignore', "\n# Ignore test coverage reports\n/coverage\n"
+    end
+    
     def git_commit(message = 'Initial commit')
       git add: "."
       git commit: %Q{ -m '#{message}'}

--- a/lib/mobile_workflow/cli/app_builder.rb
+++ b/lib/mobile_workflow/cli/app_builder.rb
@@ -88,6 +88,7 @@ CODE
       generate 'rollbar'
       gsub_file 'config/initializers/rollbar.rb', 'if Rails.env.test?', 'if Rails.env.test? || Rails.env.development?'
       copy_file 'config/initializers/mobile_workflow_rollbar.rb'
+      gsub_file 'app/jobs/application_job.rb', 'class ApplicationJob < ActiveJob::Base', "class ApplicationJob < ActiveJob::Base\n  include Rollbar::ActiveJob\n"
     end
     
     def git_commit(message = 'Initial commit')

--- a/lib/mobile_workflow/cli/app_builder.rb
+++ b/lib/mobile_workflow/cli/app_builder.rb
@@ -84,6 +84,12 @@ CODE
       append_to_file '.gitignore', "\n# Ignore test coverage reports\n/coverage\n"
     end
     
+    def rollbar
+      generate 'rollbar'
+      gsub_file 'config/initializers/rollbar.rb', 'if Rails.env.test?', 'if Rails.env.test? || Rails.env.development?'
+      copy_file 'config/initializers/mobile_workflow_rollbar.rb'
+    end
+    
     def git_commit(message = 'Initial commit')
       git add: "."
       git commit: %Q{ -m '#{message}'}

--- a/lib/mobile_workflow/cli/app_server_generator.rb
+++ b/lib/mobile_workflow/cli/app_server_generator.rb
@@ -34,6 +34,7 @@ module MobileWorkflow::Cli
         build :procfiles
         build :rspec_generator
         build :factory_bot
+        build :simplecov
         build :ability_generator
         build :active_storage if options[:s3_storage] 
         build :mobile_workflow_generator, ARGV[1]

--- a/lib/mobile_workflow/cli/app_server_generator.rb
+++ b/lib/mobile_workflow/cli/app_server_generator.rb
@@ -35,6 +35,7 @@ module MobileWorkflow::Cli
         build :rspec_generator
         build :factory_bot
         build :simplecov
+        build :rollbar
         build :ability_generator
         build :active_storage if options[:s3_storage] 
         build :mobile_workflow_generator, ARGV[1]


### PR DESCRIPTION
Resolves https://futureworkshops.atlassian.net/browse/MW-1753.

When creating a new app server, the following gems should be included:
- Rollbar
- SimpleCov
- DataMigrate