### PR TITLE
Update form default value attributes for Date and Time

### DIFF
--- a/app/models/concerns/mobile_workflow/displayable/steps/form.rb
+++ b/app/models/concerns/mobile_workflow/displayable/steps/form.rb
@@ -37,18 +37,18 @@ module MobileWorkflow
           { item_type: :text, label: label, identifier: identifier, placeholder: placeholder, optional: optional, multiline: multiline, default_text_answer: default_text_answer }
         end
     
-        def mw_form_date(label:, identifier:, optional: false, default_date_time_answer: nil)
+        def mw_form_date(label:, identifier:, optional: false, default_text_answer: nil)
           raise 'Missing label' if label.nil?
           raise 'Missing identifier' if identifier.nil?
     
-          { item_type: :date, date_type: :calendar, label: label, identifier: identifier, optional: optional, default_date_time_answer: default_date_time_answer }
+          { item_type: :date, date_type: :calendar, label: label, identifier: identifier, optional: optional, default_text_answer: default_text_answer }
         end
     
-        def mw_form_time(label:, identifier:, optional: false, default_date_time_answer: nil)
+        def mw_form_time(label:, identifier:, optional: false, default_text_answer: nil)
           raise 'Missing label' if label.nil?
           raise 'Missing identifier' if identifier.nil?
     
-          { item_type: :time, label: label, identifier: identifier, optional: optional, default_date_time_answer: default_date_time_answer }
+          { item_type: :time, label: label, identifier: identifier, optional: optional, default_text_answer: default_text_answer }
         end
     
         def mw_form_email(label:, identifier:, placeholder: nil, optional: false, default_text_answer: nil)

--- a/lib/mobile_workflow/version.rb
+++ b/lib/mobile_workflow/version.rb
@@ -1,5 +1,5 @@
 module MobileWorkflow
-  VERSION = '0.7.7'
+  VERSION = '0.7.8'
   RUBY_VERSION = '2.7.3'
   RAILS_VERSION = '6.1.3.1'
 end


### PR DESCRIPTION
- Update `MobileWorkflow::Displayable::Steps::Form` so that the default value attributes for `Date` and `Time` items are now called `default_text_answer` instead of "default_date_time_answer". This change favours consistency across AR.
- Bump version to 0.7.8