### PR TITLE
Add share attributes to styled content stack button

### DIFF
--- a/app/models/concerns/mobile_workflow/displayable/steps/styled_content/stack.rb
+++ b/app/models/concerns/mobile_workflow/displayable/steps/styled_content/stack.rb
@@ -24,14 +24,14 @@ module MobileWorkflow
             { id: id.to_s, text: text, detailText: detail_text, type: :listItem, imageURL: preview_url }.compact
           end
         
-          def mw_stack_button(id:, label:, url: nil, method: :nil, on_success: :none, style: :primary, modal_workflow_name: nil, link_url: nil, sf_symbol_name: nil, apple_system_url: nil, android_deep_link: nil, confirm_title: nil, confirm_text: nil)
+          def mw_stack_button(id:, label:, url: nil, method: :nil, on_success: :none, style: :primary, modal_workflow_name: nil, link_url: nil, sf_symbol_name: nil, apple_system_url: nil, android_deep_link: nil, confirm_title: nil, confirm_text: nil, share_text: nil, share_image_url: nil)
             raise 'Missing id' if id.nil?
             raise 'Missing label' if label.nil?
         
             validate_on_success!(on_success)
             validate_button_style!(style)
         
-            { id: id, type: :button, label: label, url: url, method: method, onSuccess: on_success, style: style, modalWorkflow: modal_workflow_name, linkURL: link_url, sfSymbolName: sf_symbol_name, appleSystemURL: apple_system_url, androidDeepLink: android_deep_link, confirmTitle: confirm_title, confirmText: confirm_text }.compact
+            { id: id, type: :button, label: label, url: url, method: method, onSuccess: on_success, style: style, modalWorkflow: modal_workflow_name, linkURL: link_url, sfSymbolName: sf_symbol_name, appleSystemURL: apple_system_url, androidDeepLink: android_deep_link, confirmTitle: confirm_title, confirmText: confirm_text, shareText: share_text, shareImageURL: share_image_url }.compact
           end
         end
       end

--- a/lib/mobile_workflow/version.rb
+++ b/lib/mobile_workflow/version.rb
@@ -1,5 +1,5 @@
 module MobileWorkflow
-  VERSION = '0.7.8'
+  VERSION = '0.7.9'
   RUBY_VERSION = '2.7.3'
   RAILS_VERSION = '6.1.3.1'
 end

--- a/spec/support/shared_examples/displayable/steps/styled_content/stack.rb
+++ b/spec/support/shared_examples/displayable/steps/styled_content/stack.rb
@@ -92,5 +92,16 @@ shared_examples_for 'styled content stack' do |param|
       it { expect(result[:onSuccess]).to eq :reload }
       it { expect(result[:style]).to eq :outline }
     end
+
+    context 'share text and share image url' do
+      let(:result) { subject.mw_stack_button(id: 0, label: 'Share Challenge', share_text: 'Challenge completed!', share_image_url: 'https://test.com/image', on_success: :none) }
+
+      it { expect(result[:id]).to eq 0 }
+      it { expect(result[:type]).to eq :button }
+      it { expect(result[:label]).to eq 'Share Challenge' }
+      it { expect(result[:shareText]).to eq 'Challenge completed!' }
+      it { expect(result[:shareImageURL]).to eq 'https://test.com/image' }
+      it { expect(result[:onSuccess]).to eq :none }
+    end
   end
 end


### PR DESCRIPTION
- Add share attributes to MobileWorkflow::Displayable::Steps::StyledContent::Stack button: `shareText` and `shareImageURL`. If present, the apps will try to download the image and share both image and text using the share sheet
- Bump version to 0.7.9