### PR TITLE
[MW-2193] Add `mw_display_link_button` method to Core Network Stack step + add `linkId` argument to `mw_stack_button` in Styled Content Network Stack step

### DIFF
--- a/app/models/concerns/mobile_workflow/displayable/steps/stack.rb
+++ b/app/models/concerns/mobile_workflow/displayable/steps/stack.rb
@@ -56,7 +56,15 @@ module MobileWorkflow
           {type: :button, label: label, appleSystemURL: apple_system_url, androidDeepLink: android_deep_link, style: style, sfSymbolName: sf_symbol_name, materialIconName: material_icon_name}.compact
         end
         alias_method :mw_display_button_for_system_url, :mw_display_system_url_button
-        
+
+        def mw_display_link_button(label:, link_id:, style: :primary, on_success: :none, sf_symbol_name: nil, material_icon_name: nil)
+          validate_on_success!(on_success)
+          validate_button_style!(style)
+
+          {type: :button, label: label, linkId: link_id, style: style, onSuccess: on_success, sfSymbolName: sf_symbol_name, materialIconName: material_icon_name}.compact
+        end
+
+        # Remove this method once V1 is no longer being used
         def mw_display_modal_workflow_button(label:, modal_workflow_name:, style: :primary, on_success: :none, sf_symbol_name: nil, material_icon_name: nil)
           validate_on_success!(on_success)
           validate_button_style!(style)

--- a/app/models/concerns/mobile_workflow/displayable/steps/styled_content/stack.rb
+++ b/app/models/concerns/mobile_workflow/displayable/steps/styled_content/stack.rb
@@ -23,15 +23,16 @@ module MobileWorkflow
         
             { id: id.to_s, text: text, detailText: detail_text, type: :listItem, imageURL: preview_url }.compact
           end
-        
-          def mw_stack_button(id:, label:, url: nil, method: :nil, on_success: :none, style: :primary, modal_workflow_name: nil, link_url: nil, sf_symbol_name: nil, apple_system_url: nil, android_deep_link: nil, confirm_title: nil, confirm_text: nil, share_text: nil, share_image_url: nil)
+
+          # Remove `modal_workflow_name` argument once V1 is no longer being used
+          def mw_stack_button(id:, label:, url: nil, method: :nil, on_success: :none, style: :primary, modal_workflow_name: nil, link_id: nil, link_url: nil, sf_symbol_name: nil, apple_system_url: nil, android_deep_link: nil, confirm_title: nil, confirm_text: nil, share_text: nil, share_image_url: nil)
             raise 'Missing id' if id.nil?
             raise 'Missing label' if label.nil?
         
             validate_on_success!(on_success)
             validate_button_style!(style)
         
-            { id: id, type: :button, label: label, url: url, method: method, onSuccess: on_success, style: style, modalWorkflow: modal_workflow_name, linkURL: link_url, sfSymbolName: sf_symbol_name, appleSystemURL: apple_system_url, androidDeepLink: android_deep_link, confirmTitle: confirm_title, confirmText: confirm_text, shareText: share_text, shareImageURL: share_image_url }.compact
+            { id: id, type: :button, label: label, url: url, method: method, onSuccess: on_success, style: style, modalWorkflow: modal_workflow_name, linkId: link_id, linkURL: link_url, sfSymbolName: sf_symbol_name, appleSystemURL: apple_system_url, androidDeepLink: android_deep_link, confirmTitle: confirm_title, confirmText: confirm_text, shareText: share_text, shareImageURL: share_image_url }.compact
           end
         end
       end

--- a/spec/support/shared_examples/displayable/steps/stack.rb
+++ b/spec/support/shared_examples/displayable/steps/stack.rb
@@ -118,6 +118,18 @@ shared_examples_for 'stack' do |param|
     it { expect(result[:materialIconName]).to eq 'World' }
   end
 
+  describe '#mw_display_link_button' do
+    let(:result) { subject.mw_display_link_button(label: 'Log In', link_id: '9e5ad548-dd58-4f9b-adbe-99c59049398', style: :primary, on_success: :none, sf_symbol_name: 'Login', material_icon_name: 'Login') }
+
+    it { expect(result[:type]).to eq :button }
+    it { expect(result[:label]).to eq 'Log In' }
+    it { expect(result[:linkId]).to eq '9e5ad548-dd58-4f9b-adbe-99c59049398' }
+    it { expect(result[:style]).to eq :primary }
+    it { expect(result[:onSuccess]).to eq :none }
+    it { expect(result[:sfSymbolName]).to eq 'Login' }
+    it { expect(result[:materialIconName]).to eq 'Login' }
+  end
+
   describe '#mw_display_modal_workflow_button' do
     let(:result) { subject.mw_display_modal_workflow_button(label: 'Log In', modal_workflow_name: 'Log In', style: :primary, on_success: :none, sf_symbol_name: 'Login', material_icon_name: 'Login') }
 

--- a/spec/support/shared_examples/displayable/steps/styled_content/stack.rb
+++ b/spec/support/shared_examples/displayable/steps/styled_content/stack.rb
@@ -82,6 +82,17 @@ shared_examples_for 'styled content stack' do |param|
       it { expect(result[:onSuccess]).to eq :none }
     end
 
+    context 'link id' do
+      let(:result) { subject.mw_stack_button(id: 0, label: 'Import', link_id: '9e5ad548-dd58-4f9b-adbe-99c59049398', on_success: :reload, style: :outline) }
+
+      it { expect(result[:id]).to eq 0 }
+      it { expect(result[:type]).to eq :button }
+      it { expect(result[:label]).to eq 'Import' }
+      it { expect(result[:linkId]).to eq '9e5ad548-dd58-4f9b-adbe-99c59049398' }
+      it { expect(result[:onSuccess]).to eq :reload }
+      it { expect(result[:style]).to eq :outline }
+    end
+
     context 'modal workflow' do
       let(:result) { subject.mw_stack_button(id: 0, label: 'Import', modal_workflow_name: 'Import Activity', on_success: :reload, style: :outline) }
 


### PR DESCRIPTION
- Resolves [MW-2193]
- Add `mw_display_link_button` method to Core Network Stack step
- Add `linkId` argument to `mw_stack_button` in Styled Content Network Stack step

[MW-2193]: https://futureworkshops.atlassian.net/browse/MW-2193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ