### PR TITLE
[W-2235] Add id property and remove identifier to/from all MobileWorkflow::Displayable::Steps::Form methods

### DIFF
--- a/app/models/concerns/mobile_workflow/displayable/steps/form.rb
+++ b/app/models/concerns/mobile_workflow/displayable/steps/form.rb
@@ -1,68 +1,78 @@
+# frozen_string_literal: true
+
+
 module MobileWorkflow
   module Displayable
     module Steps
       module Form
-        def mw_form_section(label:, identifier:)
+        def mw_form_section(label:, id:)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :section, label: label, identifier: identifier }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :section, id: id, label: label }
         end
-    
-        def mw_form_multiple_selection(label:, identifier:, multiple_selection_options:, selection_type: :single, optional: false, show_other_option: false)
+
+        def mw_form_multiple_selection(label:, multiple_selection_options:, id:, selection_type: :single, optional: false, show_other_option: false)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
+          raise 'Missing id' if id.nil?
           raise 'Missing multiple selection options' if multiple_selection_options.nil?
-    
-          { item_type: :multiple_selection, label: label, identifier: identifier, multiple_selection_options: multiple_selection_options, selection_type: selection_type, optional: optional, show_other_option: show_other_option }
+
+          { item_type: :multiple_selection, id: id, label: label,
+            multiple_selection_options: multiple_selection_options, selection_type: selection_type, optional: optional, show_other_option: show_other_option }
         end
-    
+
         def mw_form_multiple_selection_options(text:, hint: nil, is_pre_selected: false)
           raise 'Missing text' if text.nil?
-    
+
           { text: text, hint: hint, isPreSelected: is_pre_selected }
         end
-    
-        def mw_form_number(label:, identifier:, placeholder: nil, optional: false, symbol_position: :leading, default_text_answer: nil, hint: nil)
+
+        def mw_form_number(label:, id:, placeholder: nil, optional: false, symbol_position: :leading, default_text_answer: nil, hint: nil)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :number, number_type: :number, label: label, identifier: identifier, placeholder: placeholder, optional: optional, symbol_position: symbol_position, default_text_answer: default_text_answer, hint: hint }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :number, number_type: :number, id: id, label: label,
+            placeholder: placeholder, optional: optional, symbol_position: symbol_position, default_text_answer: default_text_answer, hint: hint }
         end
-    
-        def mw_form_text(label:, identifier:, placeholder: nil, optional: false, multiline: false, default_text_answer: nil)
+
+        def mw_form_text(label:, id:, placeholder: nil, optional: false, multiline: false, default_text_answer: nil)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :text, label: label, identifier: identifier, placeholder: placeholder, optional: optional, multiline: multiline, default_text_answer: default_text_answer }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :text, id: id, label: label, placeholder: placeholder,
+            optional: optional, multiline: multiline, default_text_answer: default_text_answer }
         end
-    
-        def mw_form_date(label:, identifier:, optional: false, default_text_answer: nil)
+
+        def mw_form_date(label:, id:, optional: false, default_text_answer: nil)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :date, date_type: :calendar, label: label, identifier: identifier, optional: optional, default_text_answer: default_text_answer }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :date, date_type: :calendar, id: id, label: label, optional: optional,
+            default_text_answer: default_text_answer }
         end
-    
-        def mw_form_time(label:, identifier:, optional: false, default_text_answer: nil)
+
+        def mw_form_time(label:, id:, optional: false, default_text_answer: nil)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :time, label: label, identifier: identifier, optional: optional, default_text_answer: default_text_answer }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :time, id: id, label: label, optional: optional,
+            default_text_answer: default_text_answer }
         end
-    
-        def mw_form_email(label:, identifier:, placeholder: nil, optional: false, default_text_answer: nil)
+
+        def mw_form_email(label:, id:, placeholder: nil, optional: false, default_text_answer: nil)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :email, label: label, identifier: identifier, placeholder: placeholder, optional: optional, default_text_answer: default_text_answer }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :email, id: id, label: label, placeholder: placeholder,
+            optional: optional, default_text_answer: default_text_answer }
         end
-    
-        def mw_form_password(label:, identifier:, placeholder: nil, optional: false, default_text_answer: nil, hint: nil)
+
+        def mw_form_password(label:, id:, placeholder: nil, optional: false, default_text_answer: nil, hint: nil)
           raise 'Missing label' if label.nil?
-          raise 'Missing identifier' if identifier.nil?
-    
-          { item_type: :secure, label: label, identifier: identifier, placeholder: placeholder, optional: optional, default_text_answer: default_text_answer, hint: hint }
+          raise 'Missing id' if id.nil?
+
+          { item_type: :secure, id: id, label: label, placeholder: placeholder,
+            optional: optional, default_text_answer: default_text_answer, hint: hint }
         end
       end
     end

--- a/lib/mobile_workflow/version.rb
+++ b/lib/mobile_workflow/version.rb
@@ -1,5 +1,5 @@
 module MobileWorkflow
-  VERSION = '0.8.9'
+  VERSION = '0.9.0'
   RUBY_VERSION = '2.7.3'
   RAILS_VERSION = '6.1.3.1'
 end

--- a/spec/support/shared_examples/displayable/steps/form.rb
+++ b/spec/support/shared_examples/displayable/steps/form.rb
@@ -1,19 +1,26 @@
+# frozen_string_literal: true
+
 shared_examples_for 'form' do
   describe '#mw_form_section' do
-    let(:result) { test_class.mw_form_section(label: 'Personal Information', identifier: 'info') }
+    let(:result) { test_class.mw_form_section(label: 'Personal Information', id: 1) }
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :section }
     it { expect(result[:label]).to eq 'Personal Information' }
-    it { expect(result[:identifier]).to eq 'info' }
   end
 
   describe '#mw_form_multiple_selection' do
-    let(:multiple_section_options) { [ { text: 'Alcohol Free', isPreSelected: true }, { text: 'Sunrise Yoga', isPreSelected: false } ] }
-    let(:result) { test_class.mw_form_multiple_selection(label: 'Challenge Type', identifier: 'challenge_type', multiple_selection_options: multiple_section_options, selection_type: :single, optional: false) }
+    let(:multiple_section_options) do
+      [{ text: 'Alcohol Free', isPreSelected: true }, { text: 'Sunrise Yoga', isPreSelected: false }]
+    end
+    let(:result) do
+      test_class.mw_form_multiple_selection(label: 'Challenge Type', id: 1,
+                                            multiple_selection_options: multiple_section_options, selection_type: :single, optional: false)
+    end
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :multiple_selection }
     it { expect(result[:label]).to eq 'Challenge Type' }
-    it { expect(result[:identifier]).to eq 'challenge_type' }
     it { expect(result[:multiple_selection_options]).to eq multiple_section_options }
     it { expect(result[:selection_type]).to eq :single }
     it { expect(result[:optional]).to eq false }
@@ -21,7 +28,10 @@ shared_examples_for 'form' do
   end
 
   describe '#mw_form_multiple_selection_options' do
-    let(:result) { test_class.mw_form_multiple_selection_options(text: 'Open for all', hint: 'Every user will be able to join', is_pre_selected: false) }
+    let(:result) do
+      test_class.mw_form_multiple_selection_options(text: 'Open for all', hint: 'Every user will be able to join',
+                                                    is_pre_selected: false)
+    end
 
     it { expect(result[:text]).to eq 'Open for all' }
     it { expect(result[:hint]).to eq 'Every user will be able to join' }
@@ -29,64 +39,71 @@ shared_examples_for 'form' do
   end
 
   describe '#mw_form_number' do
-    let(:result) { test_class.mw_form_number(label: 'Target Amount', identifier: 'target_amount', placeholder: '100 Eur', default_text_answer: 50) }
+    let(:result) do
+      test_class.mw_form_number(label: 'Target Amount', id: 1, placeholder: '100 Eur', default_text_answer: 50)
+    end
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :number }
     it { expect(result[:number_type]).to eq :number }
     it { expect(result[:label]).to eq 'Target Amount' }
-    it { expect(result[:identifier]).to eq 'target_amount' }
     it { expect(result[:placeholder]).to eq '100 Eur' }
     it { expect(result[:optional]).to eq false }
     it { expect(result[:default_text_answer]).to eq 50 }
   end
 
   describe '#mw_form_text' do
-    let(:result) { test_class.mw_form_text(label: 'Your Location', identifier: 'location', placeholder: 'London') }
+    let(:result) { test_class.mw_form_text(label: 'Your Location', id: 1, placeholder: 'London') }
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :text }
     it { expect(result[:label]).to eq 'Your Location' }
-    it { expect(result[:identifier]).to eq 'location' }
     it { expect(result[:placeholder]).to eq 'London' }
     it { expect(result[:optional]).to eq false }
     it { expect(result[:multiline]).to eq false }
   end
 
   describe '#mw_form_date' do
-    let(:result) { test_class.mw_form_date(label: 'Start Date', identifier: 'start_date', optional: true) }
+    let(:result) { test_class.mw_form_date(label: 'Start Date', id: 1, optional: true) }
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :date }
     it { expect(result[:date_type]).to eq :calendar }
     it { expect(result[:label]).to eq 'Start Date' }
-    it { expect(result[:identifier]).to eq 'start_date' }
     it { expect(result[:optional]).to eq true }
   end
 
   describe '#mw_form_time' do
-    let(:result) { test_class.mw_form_time(label: 'Start Time', identifier: 'start_time', optional: true) }
-
+    let(:result) { test_class.mw_form_time(label: 'Start Time', id: 1, optional: true) }
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :time }
     it { expect(result[:label]).to eq 'Start Time' }
-    it { expect(result[:identifier]).to eq 'start_time' }
     it { expect(result[:optional]).to eq true }
   end
 
   describe '#mw_form_email' do
-    let(:result) { test_class.mw_form_email(label: 'Your Email', identifier: 'email', placeholder: 'example@email.com', default_text_answer: 'montse@futureworkshops.com') }
+    let(:result) do
+      test_class.mw_form_email(label: 'Your Email', id: 1, placeholder: 'example@email.com',
+                               default_text_answer: 'montse@futureworkshops.com')
+    end
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :email }
     it { expect(result[:label]).to eq 'Your Email' }
-    it { expect(result[:identifier]).to eq 'email' }
     it { expect(result[:placeholder]).to eq 'example@email.com' }
     it { expect(result[:optional]).to eq false }
     it { expect(result[:default_text_answer]).to eq 'montse@futureworkshops.com' }
   end
 
   describe '#mw_form_password' do
-    let(:result) { test_class.mw_form_password(label: 'Your Password', identifier: 'password', placeholder: 'Secret123', hint: 'Must be at least 8 characters long') }
+    let(:result) do
+      test_class.mw_form_password(label: 'Your Password', id: 1, placeholder: 'Secret123',
+                                  hint: 'Must be at least 8 characters long')
+    end
 
+    it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :secure }
     it { expect(result[:label]).to eq 'Your Password' }
-    it { expect(result[:identifier]).to eq 'password' }
     it { expect(result[:placeholder]).to eq 'Secret123' }
     it { expect(result[:optional]).to eq false }
     it { expect(result[:hint]).to eq 'Must be at least 8 characters long' }


### PR DESCRIPTION
- Partially resolves [MW-2235]
- Add `id` property and remove `identifier` to/from all `MobileWorkflow::Displayable::Steps::Form` methods

[MW-2235]: https://futureworkshops.atlassian.net/browse/MW-2235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ