### PR TITLE
Add hint to text field in forms

### DIFF
--- a/app/models/concerns/mobile_workflow/displayable/steps/form.rb
+++ b/app/models/concerns/mobile_workflow/displayable/steps/form.rb
@@ -35,12 +35,12 @@ module MobileWorkflow
             placeholder: placeholder, optional: optional, symbol_position: symbol_position, default_text_answer: default_text_answer, hint: hint }
         end
 
-        def mw_form_text(label:, id:, placeholder: nil, optional: false, multiline: false, default_text_answer: nil)
+        def mw_form_text(label:, id:, placeholder: nil, optional: false, multiline: false, default_text_answer: nil, hint: nil)
           raise 'Missing label' if label.nil?
           raise 'Missing id' if id.nil?
 
           { item_type: :text, id: id, label: label, placeholder: placeholder,
-            optional: optional, multiline: multiline, default_text_answer: default_text_answer }
+            optional: optional, multiline: multiline, default_text_answer: default_text_answer, hint: hint }
         end
 
         def mw_form_date(label:, id:, optional: false, default_text_answer: nil)

--- a/spec/support/shared_examples/displayable/steps/form.rb
+++ b/spec/support/shared_examples/displayable/steps/form.rb
@@ -53,7 +53,7 @@ shared_examples_for 'form' do
   end
 
   describe '#mw_form_text' do
-    let(:result) { test_class.mw_form_text(label: 'Your Location', id: 1, placeholder: 'London') }
+    let(:result) { test_class.mw_form_text(label: 'Your Location', id: 1, placeholder: 'London', hint: 'Maximum 20 characters') }
 
     it { expect(result[:id]).to eq 1 }
     it { expect(result[:item_type]).to eq :text }
@@ -61,6 +61,7 @@ shared_examples_for 'form' do
     it { expect(result[:placeholder]).to eq 'London' }
     it { expect(result[:optional]).to eq false }
     it { expect(result[:multiline]).to eq false }
+    it { expect(result[:hint]).to eq 'Maximum 20 characters' }
   end
 
   describe '#mw_form_date' do


### PR DESCRIPTION
Add hint to text field in MobileWorkflow::Displayable::Steps::Form.