### PR TITLE
Bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.11.1
+Add `ATTACHMENTS_HOST` environment variable to be able to define a custom host different than a Heroku one (`https://#{app_name}.herokuapp.com`) when generating preview urls in `MobileWorkflow::Attachable#preview_url`.
+
 # 0.11.0
 Deprecate all step JSON util methods "mw_*" and move to `app_rail-steps`. Methods are aliased for backwards compatibility.
 

--- a/lib/mobile_workflow/version.rb
+++ b/lib/mobile_workflow/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MobileWorkflow
-  VERSION = '0.11.0'
+  VERSION = '0.11.1'
   RUBY_VERSION = '2.7.3'
   RAILS_VERSION = '6.1.3.1'
 end


### PR DESCRIPTION
# 0.11.1
Add `ATTACHMENTS_HOST` environment variable to be able to define a custom host different than a Heroku one (`https://#{app_name}.herokuapp.com`) when generating preview urls in `MobileWorkflow::Attachable#preview_url`.
